### PR TITLE
:sparkles: feat(authentication): login callback(#5)

### DIFF
--- a/proc_qq/src/client.rs
+++ b/proc_qq/src/client.rs
@@ -182,19 +182,12 @@ fn authenticate<'a>(
             Authentication::CallBack(wrapper) => {
                 let callback_authentication = (wrapper.clone().callback)(rq_client);
                 match callback_authentication {
-                    Some(authentication) => {
-                        match authentication {
-                            Authentication::CallBack(_) => {
-                                if wrapper.can_recursive() {
-                                    authenticate(&authentication, client)
-                                } else {
-                                    panic!("回调超出次数限制！")
-                                }
-                            }
-                            _ => authenticate(&authentication, client),
+                    Some(authentication) => match authentication {
+                        Authentication::CallBack(_) => {
+                            Err(anyhow::Error::msg("登录失败: 嵌套的回调函数"))
                         }
-                        .await
-                    }
+                        _ => authenticate(&authentication, client).await,
+                    },
                     None => Err(anyhow::Error::msg("放弃登录")),
                 }
             }

--- a/proc_qq/src/client.rs
+++ b/proc_qq/src/client.rs
@@ -182,15 +182,14 @@ fn authenticate<'a>(
             Authentication::CallBack(wrapper) => {
                 let callback_authentication = (wrapper.clone().callback)(rq_client);
                 match callback_authentication {
-                    Some(authentication) => match authentication {
-                        Authentication::CallBack(_) => {
-                            Err(anyhow::Error::msg("登录失败: 嵌套的回调函数"))
-                        }
-                        _ => authenticate(&authentication, client).await,
-                    },
-                    None => Err(anyhow::Error::msg("放弃登录")),
+                    Authentication::CallBack(_) => {
+                        Err(anyhow::Error::msg("登录失败: 嵌套的回调函数"))
+                    }
+                    Authentication::Abandon => Err(anyhow::Error::msg("放弃登录")),
+                    _ => authenticate(&authentication, client).await,
                 }
             }
+            Authentication::Abandon => Err(anyhow::Error::msg("放弃登录")),
         }
     }
     .boxed()

--- a/proc_qq/src/client.rs
+++ b/proc_qq/src/client.rs
@@ -182,16 +182,21 @@ fn authenticate<'a>(
             Authentication::CallBack(wrapper) => {
                 let callback_authentication = (wrapper.clone().callback)(rq_client);
                 match callback_authentication {
-                    Authentication::CallBack(_) => {
-                        if wrapper.can_recursive() {
-                            authenticate(&callback_authentication, client)
-                        } else {
-                            panic!("回调超出次数限制！")
+                    Some(authentication) => {
+                        match authentication {
+                            Authentication::CallBack(_) => {
+                                if wrapper.can_recursive() {
+                                    authenticate(&authentication, client)
+                                } else {
+                                    panic!("回调超出次数限制！")
+                                }
+                            }
+                            _ => authenticate(&authentication, client),
                         }
+                        .await
                     }
-                    _ => authenticate(&callback_authentication, client),
+                    None => Err(anyhow::Error::msg("放弃登录")),
                 }
-                .await
             }
         }
     }

--- a/proc_qq/src/entities.rs
+++ b/proc_qq/src/entities.rs
@@ -30,7 +30,7 @@ pub enum Authentication {
 
 #[derive(Clone)]
 pub struct CallBackWrapper {
-    pub callback: Pin<Box<fn(Arc<ricq::Client>) -> Authentication>>,
+    pub callback: Pin<Box<fn(Arc<ricq::Client>) -> Option<Authentication>>>,
     recursive_times: Rc<RefCell<u8>>,
 }
 
@@ -44,7 +44,10 @@ impl Debug for CallBackWrapper {
 }
 
 impl CallBackWrapper {
-    pub fn new(callback: fn(Arc<ricq::Client>) -> Authentication, recursive_times: u8) -> Self {
+    pub fn new(
+        callback: fn(Arc<ricq::Client>) -> Option<Authentication>,
+        recursive_times: u8,
+    ) -> Self {
         CallBackWrapper {
             callback: Pin::new(Box::new(callback)),
             recursive_times: Rc::new(RefCell::new(recursive_times)),

--- a/proc_qq/src/entities.rs
+++ b/proc_qq/src/entities.rs
@@ -24,11 +24,12 @@ pub enum Authentication {
     CustomUinPassword(CustomUinPassword),
     CustomUinPasswordMd5(CustomUinPasswordMd5),
     CallBack(CallBackWrapper),
+    Abandon,
 }
 
 #[derive(Clone)]
 pub struct CallBackWrapper {
-    pub callback: Pin<Box<fn(Arc<ricq::Client>) -> Option<Authentication>>>,
+    pub callback: Pin<Box<fn(Arc<ricq::Client>) -> Authentication>>,
 }
 
 unsafe impl Send for CallBackWrapper {}
@@ -41,7 +42,7 @@ impl Debug for CallBackWrapper {
 }
 
 impl CallBackWrapper {
-    pub fn new(callback: fn(Arc<ricq::Client>) -> Option<Authentication>) -> Self {
+    pub fn new(callback: fn(Arc<ricq::Client>) -> Authentication) -> Self {
         CallBackWrapper {
             callback: Pin::new(Box::new(callback)),
         }

--- a/proc_qq/src/entities.rs
+++ b/proc_qq/src/entities.rs
@@ -1,9 +1,7 @@
 use crate::DeviceSource::JsonFile;
-use std::cell::RefCell;
 use std::fmt::{Debug, Formatter};
 use std::future::Future;
 use std::pin::Pin;
-use std::rc::Rc;
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
@@ -31,7 +29,6 @@ pub enum Authentication {
 #[derive(Clone)]
 pub struct CallBackWrapper {
     pub callback: Pin<Box<fn(Arc<ricq::Client>) -> Option<Authentication>>>,
-    recursive_times: Rc<RefCell<u8>>,
 }
 
 unsafe impl Send for CallBackWrapper {}
@@ -44,19 +41,10 @@ impl Debug for CallBackWrapper {
 }
 
 impl CallBackWrapper {
-    pub fn new(
-        callback: fn(Arc<ricq::Client>) -> Option<Authentication>,
-        recursive_times: u8,
-    ) -> Self {
+    pub fn new(callback: fn(Arc<ricq::Client>) -> Option<Authentication>) -> Self {
         CallBackWrapper {
             callback: Pin::new(Box::new(callback)),
-            recursive_times: Rc::new(RefCell::new(recursive_times)),
         }
-    }
-
-    pub fn can_recursive(&self) -> bool {
-        *self.recursive_times.borrow_mut() -= 1;
-        *self.recursive_times.borrow() > 0
     }
 }
 


### PR DESCRIPTION
登录方式枚举添加一个回调类型(#5 1)。限制递归次数防止不停的返回回调类型造成栈溢出