### PR TITLE
:sparkles: Bot commands match string enmus

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,22 @@ async fn handle5(
 }
 ```
 
-TODO:枚举 : "请{time}{unit:时|分|秒|天}之后告诉我{text}"
+枚举
+
+请注意，枚举的匹配是通过 `|` 来分割的，第一个枚举值的前面也需要|。
+另外Uint可以时String，或者是数字类型。也可以是实现了`::proc_qq::TryFromStr`的自定义类型。
+
+```rust
+#[event(bot_command = "请{time}{unit:|时|分|秒|天}之后告诉我{text}")]
+async fn handle5(
+  _message: &MessageEvent,
+  time: i64,
+  unit: Unit,
+) -> anyhow::Result<bool> {
+  println!("text : {:?} , time : {:?} ", text, time);
+  Ok(true)
+}
+```
 
 #### 目前能匹配的类型
 ```

--- a/proc_qq/src/handler/event_args.rs
+++ b/proc_qq/src/handler/event_args.rs
@@ -587,8 +587,6 @@ impl FromTupleMatcher for Vec<Option<String>> {
     }
 }
 
-//todo 浮点类型要分开处理了
-
 macro_rules! tuple_base_ty_supplier {
     ($ty:ty, $regexp:expr) => {
         impl FromTupleMatcher for $ty {
@@ -596,9 +594,10 @@ macro_rules! tuple_base_ty_supplier {
                 let regex = regex::Regex::new($regexp).expect("proc_qq 的正则错误");
                 if let Some(find) = regex.find(matcher.0.as_str()) {
                     if find.start() == 0 {
-                        matcher.0 = matcher.0.as_str()[find.start()..].to_string();
+                        let parse = matcher.0.as_str()[find.start()..find.end()].to_string();
+                        matcher.0 = matcher.0.as_str()[find.end()..].to_string();
+                        return parse.as_str().parse::<$ty>().ok();
                     }
-                    return matcher.0.parse::<$ty>().ok();
                 }
                 None
             }

--- a/proc_qq_codegen/src/bot_command.rs
+++ b/proc_qq_codegen/src/bot_command.rs
@@ -8,6 +8,7 @@ use syn::{FnArg, ItemFn, Pat, Type};
 pub(crate) enum BotCommandRaw {
     Command(String),
     Param(String),
+    Enum(String, Vec<String>),
     Multiple(Vec<BotCommandRawTuple>),
 }
 
@@ -15,12 +16,14 @@ pub(crate) enum BotCommandRaw {
 pub(crate) enum BotCommandRawTuple {
     Command(String),
     Param(String),
+    Enum(String, Vec<String>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum BotParamsMather<'a> {
     Command(String),
     Params(&'a Ident, &'a Type),
+    Enum(&'a Ident, &'a Type, Vec<String>),
     Multiple(Vec<BotParamsMatherTuple<'a>>),
 }
 
@@ -28,9 +31,10 @@ pub enum BotParamsMather<'a> {
 pub enum BotParamsMatherTuple<'a> {
     Command(String),
     Params(&'a Ident, &'a Type),
+    Enum(&'a Ident, &'a Type, Vec<String>),
 }
 
-const command_notice: &str = r#"bot_command中的元素必须是由固定字符串和参数组合而成, 例如 "/删除 {idx}" "请{min}{time:|小时|分钟|秒钟}后提醒我{event}" "{option:|开启|关闭} 天气预报" "#;
+const COMMAND_NOTICE: &str = r#"bot_command中的元素必须是由固定字符串和参数组合而成, 例如 "/删除 {idx}" "请{min}{time:|小时|分钟|秒钟}后提醒我{event}" "{option:|开启|关闭} 天气预报" "#;
 
 // 解析命令行
 pub(crate) fn parse_bot_command(
@@ -48,8 +52,9 @@ pub(crate) fn parse_bot_command(
         let mut bot_command_item_strs = bot_command.split_whitespace();
         // 根据空格切分并循环
         while let Some(item) = bot_command_item_strs.next() {
+            // 不符合正则表达式将会提示错误
             if !elements_reg.is_match(item) {
-                abort!(&method.sig.ident.span(), command_notice);
+                abort!(&method.sig.ident.span(), COMMAND_NOTICE);
             }
             let mut element_strs = element_reg.find_iter(item);
             let mut bot_command_elements = vec![];
@@ -57,21 +62,32 @@ pub(crate) fn parse_bot_command(
             while let Some(element_str) = element_strs.next() {
                 let element_str = element_str.as_str();
                 if element_str.starts_with('{') {
-                    bot_command_elements.push(BotCommandRawTuple::Param(
-                        element_str[1..element_str.len() - 1].to_string(),
-                    ));
+                    let param = &element_str[1..element_str.len() - 1];
+                    if param.contains(":|") {
+                        let idx = param.find(":|").unwrap();
+                        let param_name = &param[..idx];
+                        let param_enum_str = &param[idx + 2..];
+                        let param_enums = param_enum_str.split('|');
+                        bot_command_elements.push(BotCommandRawTuple::Enum(
+                            param_name.to_string(),
+                            param_enums.map(|s| s.to_string()).collect(),
+                        ));
+                    } else {
+                        bot_command_elements.push(BotCommandRawTuple::Param(param.to_string()));
+                    }
                 } else {
                     bot_command_elements.push(BotCommandRawTuple::Command(element_str.to_string()));
                 }
             }
             if bot_command_elements.is_empty() {
                 // PROC_QQ逻辑错误才会运行此分支
-                abort!(&method.sig.ident.span(), command_notice);
+                abort!(&method.sig.ident.span(), COMMAND_NOTICE);
             }
             if bot_command_elements.len() == 1 {
                 bot_command_items.push(match bot_command_elements.first().unwrap() {
                     BotCommandRawTuple::Command(tmp) => BotCommandRaw::Command(tmp.clone()),
                     BotCommandRawTuple::Param(tmp) => BotCommandRaw::Param(tmp.clone()),
+                    BotCommandRawTuple::Enum(n, e) => BotCommandRaw::Enum(n.clone(), e.clone()),
                 });
             } else {
                 bot_command_items.push(BotCommandRaw::Multiple(bot_command_elements))
@@ -99,6 +115,10 @@ pub(crate) fn parse_bot_args<'a>(
                     let (pat, ty) = take_param(method, args_iter.next(), tmp.as_str());
                     BotParamsMather::Params(pat, ty)
                 }
+                BotCommandRaw::Enum(tmp, e) => {
+                    let (pat, ty) = take_param(method, args_iter.next(), tmp.as_str());
+                    BotParamsMather::Enum(pat, ty, e.clone())
+                }
                 BotCommandRaw::Multiple(multiple) => {
                     let mut multiple_result = vec![];
                     for m in multiple {
@@ -110,11 +130,15 @@ pub(crate) fn parse_bot_args<'a>(
                                 let (pat, ty) = take_param(method, args_iter.next(), tmp.as_str());
                                 BotParamsMatherTuple::Params(pat, ty)
                             }
+                            BotCommandRawTuple::Enum(tmp, e) => {
+                                let (pat, ty) = take_param(method, args_iter.next(), tmp.as_str());
+                                BotParamsMatherTuple::Enum(pat, ty, e.clone())
+                            }
                         })
                     }
                     BotParamsMather::Multiple(multiple_result)
                 }
-            })
+            });
         }
         Some(result)
     } else {

--- a/proc_qq_codegen/src/lib.rs
+++ b/proc_qq_codegen/src/lib.rs
@@ -228,7 +228,7 @@ pub fn event(args: TokenStream, input: TokenStream) -> TokenStream {
                                         mmc.append_all(quote! {#x,});
                                     }
                                     gets.append_all(quote! {
-                                        let #pat: #ty = if let Some(value) = ::proc_qq::qtuple_matcher_get_enum::<#ty>(&mut ps, vec![#mmc]) {
+                                        let #pat: #ty = if let Some(value) = ::proc_qq::tuple_matcher_get_enum::<#ty>(&mut ps, vec![#mmc]) {
                                             value
                                         } else {
                                             return Ok(false);

--- a/proc_qq_examples/src/hello_module.rs
+++ b/proc_qq_examples/src/hello_module.rs
@@ -123,7 +123,7 @@ async fn handle7(
 }
 
 // 匹配子命令
-#[event(bot_command = "/test_ban a {user} b {time}")]
+#[event(bot_command = "/test_ban a {user} b {time:|秒|分|时}")]
 async fn handle8(_message: &MessageEvent, user: String, time: i64) -> anyhow::Result<bool> {
     println!("handle8。 user : {:?} , time : {:?} ", user, time);
     Ok(true)
@@ -140,6 +140,21 @@ async fn handle9(_message: &MessageEvent, var1: i64, var2: String) -> anyhow::Re
 #[event(bot_command = "/test{var1}秒后发送{var2}")]
 async fn handle10(_message: &MessageEvent, var1: i64, var2: String) -> anyhow::Result<bool> {
     println!("handle10。 : {:?} , {:?} ", var1, var2);
+    Ok(true)
+}
+
+// 匹配子命令3
+#[event(bot_command = "/test11{time_count}{time_unit:|秒|分|时}后发送{value}")]
+async fn handle11(
+    _message: &MessageEvent,
+    time_count: i64,
+    time_unit: String,
+    value: String,
+) -> anyhow::Result<bool> {
+    println!(
+        "handle11。 : {:?} , {:?} , {:?} ",
+        time_count, time_unit, value
+    );
     Ok(true)
 }
 
@@ -164,5 +179,6 @@ pub fn module() -> Module {
         handle8,
         handle9,
         handle10,
+        handle11,
     )
 }


### PR DESCRIPTION
```rust
#[event(bot_command = "/test11{time_count}{time_unit:|秒|分|时}后发送{value}")]
async fn handle11(
    _message: &MessageEvent,
    time_count: i64,
    time_unit: String,
    value: String,
) -> anyhow::Result<bool> {
    println!(
        "handle11。 : {:?} , {:?} , {:?} ",
        time_count, time_unit, value
    );
    Ok(true)
}
```