### PR TITLE
修复枚举字段命名错误

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "proc_qq",
     "proc_qq_codegen",

--- a/proc_qq/src/handler/mod.rs
+++ b/proc_qq/src/handler/mod.rs
@@ -377,8 +377,8 @@ impl EventSender {
         match map_handlers!(
             &self,
             &DisconnectedAndOfflineEvent {},
-            ModuleEventProcess::DisconnectAndOffline,
-            ResultProcess::DisconnectAndOffline,
+            ModuleEventProcess::DisconnectedAndOffline,
+            ResultProcess::DisconnectedAndOffline,
         ) {
             MapResult::Exception(_, _) => Err(anyhow::Error::msg("err")),
             _ => Ok(()),

--- a/proc_qq/src/handler/processes.rs
+++ b/proc_qq/src/handler/processes.rs
@@ -38,7 +38,7 @@ pub enum ModuleEventProcess {
     LoginEvent(Box<dyn LoginEventProcess>),
     Message(Box<dyn MessageEventProcess>),
     ConnectedAndOnline(Box<dyn ConnectedAndOnlineEventProcess>),
-    DisconnectAndOffline(Box<dyn DisconnectedAndOfflineEventProcess>),
+    DisconnectedAndOffline(Box<dyn DisconnectedAndOfflineEventProcess>),
 
     GroupDisband(Box<dyn GroupDisbandEventProcess>),
     MemberPermissionChange(Box<dyn MemberPermissionChangeEventProcess>),

--- a/proc_qq/src/handler/results.rs
+++ b/proc_qq/src/handler/results.rs
@@ -58,7 +58,7 @@ pub enum ResultProcess {
     LoginEvent(Box<dyn LoginResultHandler>),
     Message(Box<dyn MessageResultHandler>),
     ConnectedAndOnline(Box<dyn ConnectedAndOnlineResultHandler>),
-    DisconnectAndOffline(Box<dyn DisconnectedAndOfflineResultHandler>),
+    DisconnectedAndOffline(Box<dyn DisconnectedAndOfflineResultHandler>),
 
     GroupDisband(Box<dyn GroupDisbandResultHandler>),
     MemberPermissionChange(Box<dyn MemberPermissionChangeResultHandler>),

--- a/proc_qq_template/src/database/redis.rs
+++ b/proc_qq_template/src/database/redis.rs
@@ -40,7 +40,7 @@ where
         .unwrap()
         .get_async_connection()
         .await?
-        .set_ex(key, value, expire_seconds)
+        .set_ex(key, value, expire_seconds as u64)
         .await
 }
 


### PR DESCRIPTION
枚举字段名写错了，导致#[event]宏会报这个错误: "error [E0599]: no variant or associated item named 'DisconnectAndOffline' found for enum 'ModuleEventProcess' in the current scope"。